### PR TITLE
No use of docker compose in making a docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ docker-compose*
 README.md
 LICENSE
 .vscode
+.env

--- a/config/config.js
+++ b/config/config.js
@@ -1,4 +1,5 @@
-let env = process.env;
+require("dotenv").config();
+let env = process.env
 if (process.env.DEBUG_MODE === true || process.env.DEBUG_MODE === "true") {
   // in the deployment, we'll always use main env. this below is for local debug mode
   if (process.env.NODE_ENV === "development") {
@@ -10,5 +11,5 @@ if (process.env.DEBUG_MODE === true || process.env.DEBUG_MODE === "true") {
   }
 }
 module.exports = {
-  ...env.parsed,
+  ...env,
 };

--- a/config/config.js
+++ b/config/config.js
@@ -1,10 +1,13 @@
-let env
-if (process.env.NODE_ENV === 'development') {
-  env = require('dotenv').config();
-} else if (process.env.NODE_ENV === 'staging') {
-  env = require('dotenv').config({ path: 'staging.env' });
-} else if (process.env.NODE_ENV === 'production') {
-  env = require('dotenv').config({ path: 'prod.env' });
+let env = process.env;
+if (process.env.DEBUG_MODE === true || process.env.DEBUG_MODE === "true") {
+  // in the deployment, we'll always use main env. this below is for local debug mode
+  if (process.env.NODE_ENV === "development") {
+    env = require("dotenv").config();
+  } else if (process.env.NODE_ENV === "staging") {
+    env = require("dotenv").config({ path: "staging.env" });
+  } else if (process.env.NODE_ENV === "production") {
+    env = require("dotenv").config({ path: "prod.env" });
+  }
 }
 module.exports = {
   ...env.parsed,

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,4 +1,5 @@
 
+# remove .test to run docker image container with the given env. If docker image is made with the env_file, then the project env will be used in the image rather than the config file in our app
 version: "3.7"
 services:
   api-portal:


### PR DESCRIPTION
Using docker-compose with env file will create a image that use the .env in the project, which may be diff from our config. So, remove it from app, and only use when the image is to be used as standalone docker image
@nishlashakya @Anthony-Michel 
The config has been changed too @nishlashakya 
Now to use the local env, set the given env key to true